### PR TITLE
install libnf.h file

### DIFF
--- a/libnf/c/include/Makefile.am
+++ b/libnf/c/include/Makefile.am
@@ -1,3 +1,5 @@
 
 EXTRA_DIST = libnf.h
 
+include_HEADERS = libnf.h
+


### PR DESCRIPTION
Header file was not installed via standard make install. This patch adds libnf.h to HEADERS that are automatically installed into $includedir.
