### PR TITLE
Fixed invalid data type for getopt() return value.

### DIFF
--- a/libnf/c/bin/nfdumpp.c
+++ b/libnf/c/bin/nfdumpp.c
@@ -177,7 +177,7 @@ int main(int argc, char **argv) {
 	int sortfield = 0;
 	int sortbits4 = 0;
 	int sortbits6 = 0;
-    char c;
+	int c;
 	output_t output;
 //	lnf_filter_t *filterp;
 	

--- a/libnf/c/examples/lnf_ex01_writer.c
+++ b/libnf/c/examples/lnf_ex01_writer.c
@@ -42,7 +42,7 @@ int main (int argc, char **argv) {
 	int aggip = 1;
 	int append = 0;
 	char *filename = FILENAME;
-	char c;
+	int c;
 
 	while ((c = getopt (argc, argv, "acn:f:r:?")) != -1) {
 		switch (c) {

--- a/libnf/c/examples/lnf_ex02_reader.c
+++ b/libnf/c/examples/lnf_ex02_reader.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
     int filter = 1;
     int fget = 1;
     char *filename = FILENAME;
-    char c;
+    int c;
 
 	while ((c = getopt (argc, argv, "pPFGf:1:2:")) != -1) {
 		switch (c) {

--- a/libnf/c/examples/lnf_ex03_aggreg.c
+++ b/libnf/c/examples/lnf_ex03_aggreg.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     int print = 1;
     int printa = 1;
     char *filename = FILENAME;
-    char c;
+    int c;
 
 	while ((c = getopt (argc, argv, "pPAf:")) != -1) {
 		switch (c) {

--- a/libnf/c/examples/lnf_ex04_threads.c
+++ b/libnf/c/examples/lnf_ex04_threads.c
@@ -154,7 +154,7 @@ int main(int argc, char **argv) {
     int printa = 1;
 	int numthreads = 1;
 	int listmode = 0;
-    char c;
+	int c;
 
 	while ((c = getopt (argc, argv, "lnpPAt:")) != -1) {
 		switch (c) {

--- a/libnf/c/examples/lnf_ex05_memtrans.c
+++ b/libnf/c/examples/lnf_ex05_memtrans.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
     int print = 1;
     int printa = 1;
     char *filename = FILENAME;
-    char c;
+    int c;
 
 	char buff[LNF_MAX_RAW_LEN];
 	int datasize;

--- a/libnf/c/examples/lnf_ex06_readreset.c
+++ b/libnf/c/examples/lnf_ex06_readreset.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     int print = 1;
     int printa = 1;
     char *filename = FILENAME;
-    char c;
+    int c;
 
 	while ((c = getopt (argc, argv, "pPAf:")) != -1) {
 		switch (c) {

--- a/libnf/c/examples/lnf_ex07_filter.c
+++ b/libnf/c/examples/lnf_ex07_filter.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
 	int if2 = 0;
 
     char *filename = FILENAME;
-    char c;
+    int c;
 
 	while ((c = getopt (argc, argv, "f:1:")) != -1) {
 		switch (c) {

--- a/libnf/c/examples/lnf_ex08_statistics.c
+++ b/libnf/c/examples/lnf_ex08_statistics.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
     int print = 1;
     int printa = 1;
     char *filename = FILENAME;
-    char c;
+    int c;
 
 	while ((c = getopt (argc, argv, "pPAf:")) != -1) {
 		switch (c) {

--- a/libnf/c/examples/lnf_ex09_memlookup.c
+++ b/libnf/c/examples/lnf_ex09_memlookup.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv) {
     int printa = 1;
 	int len;
     char *filename = FILENAME;
-    char c;
+    int c;
 	char buff[1024];
 
 	while ((c = getopt (argc, argv, "pPAf:")) != -1) {

--- a/libnf/c/examples/lnf_ex10_listmode.c
+++ b/libnf/c/examples/lnf_ex10_listmode.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
     int print = 1;
     int printa = 1;
     char *filename = FILENAME;
-    char c;
+    int c;
 
 	while ((c = getopt (argc, argv, "pPAf:")) != -1) {
 		switch (c) {


### PR DESCRIPTION
The signedness of a char is implementation-defined. On ARMv7 architecture, where char is unsigned by default, this was causing an infinite loop during arguments parsing.
