### PR TITLE
Large file support: add autoconf macro for LFS

### DIFF
--- a/libnf/c/configure.ac
+++ b/libnf/c/configure.ac
@@ -227,6 +227,9 @@ if test "$ac_cv_struct_semun" = "yes"; then
 	AC_DEFINE(HAVE_SEMUN, 1, [Define if sys/sem.h defines struct semun])
 fi
 
+#arrange for 64-bit file offsets, known as large-file support
+#sometimes needed on 32bit systems
+AC_SYS_LARGEFILE
 
 AC_OUTPUT(Makefile libnf.spec libnf.doxygen include/Makefile src/Makefile bin/Makefile examples/Makefile)
 


### PR DESCRIPTION
Useful for 32bit systems, on 64bit systems has usually no effect.

https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/System-Services.html
http://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
http://www.unix.org/version2/whatsnew/lfs.html
